### PR TITLE
`Push_swap` Actions: Add functions to handle all `push_swap` operations

### DIFF
--- a/push_swap/acts/ft_pa.c
+++ b/push_swap/acts/ft_pa.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_pa.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/07 00:14:47 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:26:14 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_pa(size_t n, t_stack *stack_a, t_stack *stack_b, bool print)
+{
+	if (!stack_b || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_push(stack_a, stack_b->data[0]);
+		ft_stack_pop(stack_b);
+		
+		if (print)
+			ft_putendl_fd("pa", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_pb.c
+++ b/push_swap/acts/ft_pb.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_pb.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/08 00:57:22 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:26:56 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_pb(size_t n, t_stack *stack_a, t_stack *stack_b, bool print)
+{
+	if (!stack_a || !stack_a->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_push(stack_b, stack_a->data[0]);
+		ft_stack_pop(stack_a);
+
+		if (print)
+			ft_putendl_fd("pb", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_ra.c
+++ b/push_swap/acts/ft_ra.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_ra.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/08 01:48:06 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:27:21 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_ra(size_t n, t_stack *stack_a, bool print)
+{
+	if (!stack_a || !stack_a->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_rotate(stack_a);
+
+		if (print)
+			ft_putendl_fd("ra", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_rb.c
+++ b/push_swap/acts/ft_rb.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_rb.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/08 01:58:41 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:27:49 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_rb(size_t n, t_stack *stack_b, bool print)
+{
+	if (!stack_b || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_rotate(stack_b);
+
+		if (print)
+			ft_putendl_fd("rb", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_rr.c
+++ b/push_swap/acts/ft_rr.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_rr.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/09 00:15:56 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:27:59 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_rr(size_t n, t_stack *stack_a, t_stack *stack_b, bool print)
+{
+	if (!stack_a || !stack_b || !stack_a->size || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_rotate(stack_a);
+		ft_stack_rotate(stack_b);
+
+		if (print)
+			ft_putendl_fd("rr", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_rra.c
+++ b/push_swap/acts/ft_rra.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_rra.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/09 00:22:26 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:28:15 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_rra(size_t n, t_stack *stack_a, bool print)
+{
+	if (!stack_a || !stack_a->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_rrotate(stack_a);
+
+		if (print)
+			ft_putendl_fd("rra", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_rrb.c
+++ b/push_swap/acts/ft_rrb.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_rrb.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/09 00:22:45 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:28:32 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_rrb(size_t n, t_stack *stack_b, bool print)
+{
+	if (!stack_b || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_rrotate(stack_b);
+
+		if (print)
+			ft_putendl_fd("rrb", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_rrr.c
+++ b/push_swap/acts/ft_rrr.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_rrr.c                                           :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/09 00:23:07 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:28:45 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_rrr(size_t n, t_stack *stack_a, t_stack *stack_b, bool print)
+{
+	if (!stack_a || !stack_b || !stack_a->size || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_rrotate(stack_a);
+		ft_stack_rrotate(stack_b);
+
+		if (print)
+			ft_putendl_fd("rrr", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_sa.c
+++ b/push_swap/acts/ft_sa.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_sa.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/06 23:48:53 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:28:58 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_sa(size_t n, t_stack *stack_a, bool print)
+{
+	if (!stack_a || !stack_a->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_swap(stack_a);
+
+		if (print)
+			ft_putendl_fd("sa", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_sb.c
+++ b/push_swap/acts/ft_sb.c
@@ -1,0 +1,27 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_sb.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/06 23:55:10 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:29:07 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_sb(size_t n, t_stack *stack_b, bool print)
+{
+	if (!stack_b || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_swap(stack_b);
+
+		if (print)
+			ft_putendl_fd("sb", STDOUT_FILENO);
+	}
+}

--- a/push_swap/acts/ft_ss.c
+++ b/push_swap/acts/ft_ss.c
@@ -1,0 +1,28 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ft_ss.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: arocha-b <arocha-b@student.42porto.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/05/07 00:02:28 by arocha-b          #+#    #+#             */
+/*   Updated: 2024/09/10 00:29:22 by arocha-b         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../push_swap.h"
+
+void ft_ss(size_t n, t_stack *stack_a, t_stack *stack_b, bool print)
+{
+	if (!stack_a || !stack_b || !stack_a->size || !stack_b->size)
+		return;
+
+	while (n-- > 0)
+	{
+		ft_stack_swap(stack_a);
+		ft_stack_swap(stack_b);
+
+		if (print)
+			ft_putendl_fd("ss", STDOUT_FILENO);
+	}
+}


### PR DESCRIPTION
# Overview

This PR introduces new functions that implement all the necessary operations for the `push_swap` program. These functions handle the core stack manipulations while also printing the operation type as required by the `push_swap` subject. Additionally, each function has an argument that allows the operation to be repeated for a specified number of times.

## Key Changes

Was implemented the following operations:

`sa`: Swap the first two elements of stack `a`.
`sb`: Swap the first two elements of stack `b`.
`ss`: Swap the first two elements of both stacks `a` and `b`.
`pa`: Push the top element of stack `b` onto stack `a`.
`pb`: Push the top element of stack `a` onto stack `b`.
`ra`: Rotate stack `a` upwards.
`rb`: Rotate stack `b` upwards.
`rr`: Rotate both stacks `a` and `b` upwards.
`rra`: Rotate stack `a` downwards.
`rrb`: Rotate stack `b` downwards.
`rrr`: Rotate both stacks `a` and `b` downwards.

These operations are essential for the functioning of `push_swap` and will be used in the sorting algorithm. Modularizing the operations improves readability and maintainability.
