### PR TITLE
`Push_swap` Tests: Fix relative paths for test scripts

### DIFF
--- a/push_swap/tests/setup.sh
+++ b/push_swap/tests/setup.sh
@@ -2,11 +2,12 @@
 
 set -euo pipefail
 
-ROOT=$HOME/push_swap2
+ROOT=$(cd "$(dirname "$0")" && cd ../../ && pwd)
 
 MK_PATH=$ROOT
-PS_BIN=$ROOT/push_swap/push_swap
-CK_BIN=$ROOT/push_swap/tests/checker_linux
+PS_DIR=$ROOT/push_swap
+PS_BIN=$PS_DIR/push_swap
+CK_BIN=$PS_DIR/tests/checker_linux
 
 if [[ ! -f $CK_BIN ]]; then
 	echo "Checker program not found."

--- a/push_swap/tests/test.sh
+++ b/push_swap/tests/test.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
-ROOT=$HOME/push_swap2/push_swap
-bash $ROOT/tests/setup.sh
-bash $ROOT/tests/test_args.sh
+ROOT=$(cd "$(dirname "$0")" && cd ../../ && pwd)
+TESTS_DIR=$ROOT/push_swap/tests
+
+bash $TESTS_DIR/setup.sh
+bash $TESTS_DIR/test_args.sh
 echo ""
-bash $ROOT/tests/test_sort.sh
+bash $TESTS_DIR/test_sort.sh

--- a/push_swap/tests/test_args.sh
+++ b/push_swap/tests/test_args.sh
@@ -2,8 +2,10 @@
 
 set -euo pipefail
 
-ROOT=$HOME/push_swap2/push_swap
-PS_BIN=$ROOT/push_swap
+ROOT=$(cd "$(dirname "$0")" && cd ../../ && pwd)
+
+PS_DIR=$ROOT/push_swap
+PS_BIN=$PS_DIR/push_swap
 
 if [ ! -f $PS_BIN ]; then
 	echo "Push_swap binary not found. Please, execute the tests with test.sh script."

--- a/push_swap/tests/test_sort.sh
+++ b/push_swap/tests/test_sort.sh
@@ -2,9 +2,11 @@
 
 set -euo pipefail
 
-ROOT=$HOME/push_swap2/push_swap
-PS_BIN=$ROOT/push_swap
-CK_BIN=$ROOT/tests/checker_linux
+ROOT=$(cd "$(dirname "$0")" && cd ../../ && pwd)
+
+PS_DIR=$ROOT/push_swap
+PS_BIN=$PS_DIR/push_swap
+CK_BIN=$PS_DIR/tests/checker_linux
 
 if [ ! -f $PS_BIN ]; then
 	echo "Push_swap binary not found. Please, execute the tests with test.sh script."


### PR DESCRIPTION
# Overview

This PR fixes issues related to hardcoded paths in the test scripts for the `push_swap` project. The previous absolute paths caused the tests to break when the project directory was moved or restructured. By switching to relative paths, the test scripts are now more flexible and can be run from different locations within the project without modification.

## Changes

- Updated test scripts to use relative paths for the `push_swap` binary and the `checker_linux` executable.

- Improved path resolution to dynamically reference the project root directory.

- Ensured compatibility across different environments and folder structures.

This update allows for smoother integration and execution of test scripts, making them more portable and adaptable to various project setups. It improves the overall development workflow by eliminating path-related issues when running tests after directory changes.